### PR TITLE
Harden GovBudgetChecker auth, job reliability, and dependencies

### DIFF
--- a/api/job_queue.py
+++ b/api/job_queue.py
@@ -7,7 +7,6 @@ resume by scanning persisted job status files.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import time
 from pathlib import Path
@@ -107,10 +106,7 @@ class DurableJobQueue:
             }
         )
         try:
-            (job_dir / "status.json").write_text(
-                json.dumps(payload, ensure_ascii=False),
-                encoding="utf-8",
-            )
+            runtime.write_json_file(job_dir / "status.json", payload)
         except Exception:
             logger.exception("Failed to rewrite resumed status for %s", job_dir.name)
 

--- a/api/main.py
+++ b/api/main.py
@@ -147,7 +147,7 @@ def _safe_write(job_dir: Path, payload: Dict[str, Any]) -> None:
         existing = runtime.read_json_file(status_file, default={})
         for key, value in runtime.extract_job_status_context(existing).items():
             merged_payload.setdefault(key, value)
-        status_file.write_text(json.dumps(merged_payload, ensure_ascii=False), encoding="utf-8")
+        runtime.write_json_file(status_file, merged_payload)
     except Exception as e:
         (job_dir / "status_error.log").write_text(str(e), encoding="utf-8")
 
@@ -234,6 +234,34 @@ async def _run_pipeline(job_dir: Path) -> None:
     - 调用 build_issues_payload 打包返回
     - 写入 status.json（result.summary / result.issues / result.meta）
     """
+    try:
+        PIPELINE_TIMEOUT_SEC = int(os.getenv("PIPELINE_TIMEOUT_SEC", "600"))
+    except Exception:
+        PIPELINE_TIMEOUT_SEC = 600
+
+    try:
+        await asyncio.wait_for(
+            _run_pipeline_inner(job_dir),
+            timeout=PIPELINE_TIMEOUT_SEC,
+        )
+    except asyncio.TimeoutError:
+        _safe_write(
+            job_dir,
+            {
+                "job_id": job_dir.name,
+                "status": "error",
+                "error": f"pipeline_timeout_{PIPELINE_TIMEOUT_SEC}s",
+                "ts": time.time(),
+            },
+        )
+        await persist_analysis_job_snapshot(
+            runtime.read_json_file(job_dir / "status.json", default={}),
+            include_results=True,
+        )
+
+
+async def _run_pipeline_inner(job_dir: Path) -> None:
+    """Pipeline body isolated for timeout wrapping."""
     # 提前初始化 provider_stats，确保处理中/失败态也能返回该字段
     provider_stats: List[Dict[str, Any]] = []
     structured_ingest_summary: Dict[str, Any] = {}

--- a/api/routes/analyze.py
+++ b/api/routes/analyze.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, Request
 
 from api import runtime
+from api.auth_utils import require_login
 
 router = APIRouter()
 
@@ -16,6 +17,7 @@ router = APIRouter()
 @router.post("/analyze2/{job_id}")
 @router.post("/api/analyze2/{job_id}")
 async def analyze_job(job_id: str, request: Request):
+    require_login(request)
     body: Optional[Dict[str, Any]] = None
     try:
         parsed = await request.json()
@@ -29,6 +31,7 @@ async def analyze_job(job_id: str, request: Request):
 
 @router.post("/api/documents/{version_id}/run")
 async def run_document(version_id: str, request: Request):
+    require_login(request)
     body: Optional[Dict[str, Any]] = None
     try:
         parsed = await request.json()

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -75,11 +75,12 @@ async def auth_login(request: Request):
     store = runtime.require_user_store()
     try:
         token, user = store.login(username, password)
-    except KeyError:
-        raise HTTPException(status_code=401, detail="username not found")
     except PermissionError as e:
-        if str(e) == "user is disabled":
+        msg = str(e)
+        if msg == "user is disabled":
             raise HTTPException(status_code=403, detail="user is disabled")
+        if "locked" in msg:
+            raise HTTPException(status_code=429, detail=msg)
         raise HTTPException(status_code=401, detail="invalid username or password")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from api import runtime
-from api.auth_utils import require_admin
+from api.auth_utils import require_admin, require_login
 from api.routes.organizations import clear_department_stats_cache
 from src.services.analysis_result_store import (
     get_persisted_analysis_job_detail,
@@ -361,6 +361,7 @@ async def delete_job(job_id: str, request: Request):
 
 @router.post("/api/jobs/{job_id}/associate")
 async def associate_job(job_id: str, request: Request):
+    require_login(request)
     body = await request.json()
     org_id = (body or {}).get("org_id")
     if not org_id:
@@ -383,6 +384,7 @@ async def associate_job(job_id: str, request: Request):
 
 @router.post("/api/jobs/{job_id}/reanalyze")
 async def reanalyze_job(job_id: str, request: Request):
+    require_login(request)
     try:
         body = await request.json()
     except Exception:
@@ -392,6 +394,7 @@ async def reanalyze_job(job_id: str, request: Request):
 
 @router.post("/api/jobs/{job_id}/issues/ignore")
 async def ignore_job_issue(job_id: str, request: Request):
+    require_login(request)
     try:
         body = await request.json()
     except Exception:

--- a/api/runtime.py
+++ b/api/runtime.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shutil
+import tempfile
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, Set
@@ -250,8 +251,29 @@ def read_json_file(
 
 
 def write_json_file(path: Path, payload: Dict[str, Any]) -> None:
-    """Write JSON payload with UTF-8 encoding."""
-    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    """Write JSON payload atomically via unique temp file + rename."""
+    tmp_fd = None
+    tmp_path = None
+    try:
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            suffix=".tmp", dir=str(path.parent)
+        )
+        tmp_path = Path(tmp_name)
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        os.write(tmp_fd, data)
+        os.fsync(tmp_fd)
+        os.close(tmp_fd)
+        tmp_fd = None
+        tmp_path.replace(path)
+    except BaseException:
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def calculate_file_checksum(path: Path, chunk_size: int = 1024 * 1024) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # 后端与AI微服务依赖
-fastapi==0.116.2
+fastapi==0.121.3
 uvicorn[standard]==0.35.0
 python-multipart==0.0.29
 pypdf==6.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # 后端与AI微服务依赖
 fastapi==0.116.2
 uvicorn[standard]==0.35.0
-python-multipart==0.0.20
-pypdf==5.0.1
+python-multipart==0.0.29
+pypdf==6.12.2
 PyMuPDF>=1.24.0
 pdfplumber>=0.11.0
 rapidfuzz>=3.9.0

--- a/src/services/user_store.py
+++ b/src/services/user_store.py
@@ -33,6 +33,9 @@ _INSECURE_DEFAULT_ADMIN_PASSWORDS = {
     "change_me_to_a_strong_secret",
 }
 
+_LOCKOUT_THRESHOLD = int(os.getenv("LOGIN_LOCKOUT_THRESHOLD", "5"))
+_LOCKOUT_DURATION = int(os.getenv("LOGIN_LOCKOUT_DURATION", "900"))
+
 
 def _env_flag(name: str, default: bool = False) -> bool:
     raw = os.getenv(name)
@@ -92,6 +95,7 @@ class UserStore:
 
         self._lock = threading.RLock()
         self._users: Dict[str, Dict[str, Any]] = {}
+        self._login_failures: Dict[str, List[float]] = {}
 
         self._ensure_data_dir()
         self._load_users()
@@ -232,13 +236,13 @@ class UserStore:
         if raw_secret:
             return raw_secret.encode("utf-8")
 
-        fallback = "test-user-session-secret" if _TESTING else "dev-user-session-secret"
-        if not _TESTING:
-            logger.warning(
-                "USER_SESSION_SECRET and GOVBUDGET_API_KEY are both empty; "
-                "falling back to a development-only session secret."
-            )
-        return fallback.encode("utf-8")
+        if _TESTING:
+            return b"test-user-session-secret"
+
+        raise RuntimeError(
+            "USER_SESSION_SECRET and GOVBUDGET_API_KEY are both empty. "
+            "Set at least one before starting the service."
+        )
 
     @staticmethod
     def _b64url_encode(raw: bytes) -> str:
@@ -600,22 +604,50 @@ class UserStore:
             del self._users[canonical]
             self._save_users_locked()
 
+    def _check_lockout(self, canonical_username: str) -> None:
+        """Raise PermissionError if the user account is locked out."""
+        now = time.time()
+        attempts = self._login_failures.get(canonical_username, [])
+        recent = [t for t in attempts if now - t < _LOCKOUT_DURATION]
+        if len(recent) >= _LOCKOUT_THRESHOLD:
+            remaining = int(_LOCKOUT_DURATION - (now - recent[0]))
+            raise PermissionError(
+                f"account locked due to too many failed attempts; "
+                f"try again in {remaining} seconds"
+            )
+
+    def _record_failure(self, canonical_username: str) -> None:
+        """Record a failed login attempt timestamp."""
+        now = time.time()
+        attempts = self._login_failures.get(canonical_username, [])
+        recent = [t for t in attempts if now - t < _LOCKOUT_DURATION]
+        recent.append(now)
+        self._login_failures[canonical_username] = recent
+
+    def _clear_failures(self, canonical_username: str) -> None:
+        """Clear failed login attempts after a successful login."""
+        self._login_failures.pop(canonical_username, None)
+
     def login(self, username: str, password: str) -> Tuple[str, Dict[str, Any]]:
         canonical = self._normalize_username(self._validate_username(username))
         plain_password = self._require_password(password)
 
         with self._lock:
+            self._check_lockout(canonical)
             self._load_users_locked()
             user = self._users.get(canonical)
             if user is None:
-                raise KeyError("user not found")
+                self._record_failure(canonical)
+                raise PermissionError("invalid username or password")
             if not bool(user.get("is_active", True)):
                 raise PermissionError("user is disabled")
 
             password_hash = str(user.get("password_hash") or "")
             if not self._verify_password(plain_password, password_hash):
+                self._record_failure(canonical)
                 raise PermissionError("invalid username or password")
 
+            self._clear_failures(canonical)
             token = self._build_session_token_locked(user)
             return token, self._public_user(user)
 

--- a/tests/test_p1_reliability.py
+++ b/tests/test_p1_reliability.py
@@ -1,0 +1,144 @@
+"""P1 reliability tests: atomic write_json_file and pipeline timeout."""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+os.environ.setdefault("TESTING", "true")
+
+from api import runtime
+
+
+# ---------------------------------------------------------------------------
+# write_json_file — atomic write
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWriteJsonFile:
+    def test_writes_valid_json(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        payload = {"key": "value", "count": 42, "nested": {"a": [1, 2]}}
+        runtime.write_json_file(target, payload)
+        assert target.exists()
+        loaded = json.loads(target.read_text(encoding="utf-8"))
+        assert loaded == payload
+
+    def test_overwrite_preserves_valid_json(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        runtime.write_json_file(target, {"v": 1})
+        runtime.write_json_file(target, {"v": 2})
+        loaded = json.loads(target.read_text(encoding="utf-8"))
+        assert loaded == {"v": 2}
+
+    def test_no_temp_file_left_on_success(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        runtime.write_json_file(target, {"ok": True})
+        tmp_candidates = list(tmp_path.glob("*.tmp"))
+        assert tmp_candidates == [], f"stale temp files: {tmp_candidates}"
+
+    def test_old_file_preserved_on_write_error(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        runtime.write_json_file(target, {"original": True})
+        original_content = target.read_text(encoding="utf-8")
+
+        class BadPayload:
+            pass
+
+        with pytest.raises(TypeError):
+            runtime.write_json_file(target, {"bad": BadPayload()})
+
+        assert target.read_text(encoding="utf-8") == original_content
+
+    def test_no_temp_file_left_on_error(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        target.write_text("{}", encoding="utf-8")
+
+        class BadPayload:
+            pass
+
+        with pytest.raises(TypeError):
+            runtime.write_json_file(target, {"bad": BadPayload()})
+
+        tmp_candidates = list(tmp_path.glob("*.tmp"))
+        assert tmp_candidates == [], f"stale temp files after error: {tmp_candidates}"
+
+    def test_unicode_content_roundtrip(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        payload = {"org": "上海市普陀区财政局", "issues": ["勾稽错误", "求和不平"]}
+        runtime.write_json_file(target, payload)
+        loaded = json.loads(target.read_text(encoding="utf-8"))
+        assert loaded == payload
+
+    def test_concurrent_writes_no_conflict(self, tmp_path: Path) -> None:
+        """Multiple write_json_file calls to different files in same dir."""
+        targets = [tmp_path / f"job_{i}.json" for i in range(10)]
+        for i, target in enumerate(targets):
+            runtime.write_json_file(target, {"index": i})
+        for i, target in enumerate(targets):
+            loaded = json.loads(target.read_text(encoding="utf-8"))
+            assert loaded == {"index": i}
+        assert list(tmp_path.glob("*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# Pipeline timeout
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineTimeout:
+    @pytest.mark.asyncio
+    async def test_pipeline_timeout_writes_error_status(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from api import main as pipeline_mod
+
+        job_dir = tmp_path / "job-timeout-test"
+        job_dir.mkdir(parents=True)
+
+        async def _slow_inner(_job_dir: Path) -> None:
+            await asyncio.sleep(999)
+
+        monkeypatch.setattr(pipeline_mod, "_run_pipeline_inner", _slow_inner)
+        monkeypatch.setattr(
+            pipeline_mod, "persist_analysis_job_snapshot", AsyncMock()
+        )
+        monkeypatch.setenv("PIPELINE_TIMEOUT_SEC", "1")
+
+        await pipeline_mod._run_pipeline(job_dir)
+
+        status_file = job_dir / "status.json"
+        assert status_file.exists()
+        payload = json.loads(status_file.read_text(encoding="utf-8"))
+        assert payload["status"] == "error"
+        assert "pipeline_timeout" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_pipeline_normal_completion_untouched(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Normal pipeline that finishes quickly should not be affected."""
+        from api import main as pipeline_mod
+
+        job_dir = tmp_path / "job-normal-test"
+        job_dir.mkdir(parents=True)
+        (job_dir / "dummy.pdf").write_bytes(b"%PDF-1.4\n%%EOF\n")
+
+        called = False
+
+        async def _fast_inner(_job_dir: Path) -> None:
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(pipeline_mod, "_run_pipeline_inner", _fast_inner)
+        monkeypatch.setattr(
+            pipeline_mod, "persist_analysis_job_snapshot", AsyncMock()
+        )
+        monkeypatch.setenv("PIPELINE_TIMEOUT_SEC", "600")
+
+        await pipeline_mod._run_pipeline(job_dir)
+
+        assert called is True

--- a/tests/test_user_auth_api.py
+++ b/tests/test_user_auth_api.py
@@ -319,3 +319,94 @@ def test_admin_sensitive_action_writes_audit_log(client: TestClient, tmp_path: P
     assert "organization.create" in content
     assert "admin" in content
     assert department_name in content
+
+
+# ---------------------------------------------------------------------------
+# Login brute-force lockout tests (P0-1)
+# ---------------------------------------------------------------------------
+
+
+def test_login_lockout_after_threshold(client: TestClient):
+    """Attempts 1-5 return 401; attempt 6 returns 429."""
+    for i in range(1, 6):
+        resp = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": f"wrong_{i}"},
+            headers=_headers(),
+        )
+        assert resp.status_code == 401, f"attempt {i} should be 401"
+
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "wrong_6"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 429, f"attempt 6 should be 429, got {resp.status_code}"
+    assert "locked" in resp.json()["detail"]
+
+
+def test_login_lockout_persists_across_attempts(client: TestClient):
+    """After lockout, further attempts also return 429."""
+    for i in range(6):
+        client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": f"wrong_{i}"},
+            headers=_headers(),
+        )
+
+    for i in range(3):
+        resp = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": f"still_wrong_{i}"},
+            headers=_headers(),
+        )
+        assert resp.status_code == 429
+
+
+def test_successful_login_clears_failure_count(client: TestClient):
+    """A successful login resets the failure counter."""
+    for i in range(4):
+        client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": f"wrong_{i}"},
+            headers=_headers(),
+        )
+
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "admin123"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 200
+
+    for i in range(4):
+        resp = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": f"wrong_after_{i}"},
+            headers=_headers(),
+        )
+        assert resp.status_code == 401, f"attempt {i} after reset should be 401"
+
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "admin123"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 200
+
+
+def test_nonexistent_user_and_wrong_password_same_error(client: TestClient):
+    """Non-existent user and wrong password must return the same error message."""
+    resp_missing = client.post(
+        "/api/auth/login",
+        json={"username": "ghost_user_xyz", "password": "any"},
+        headers=_headers(),
+    )
+    resp_wrong = client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "wrong_password"},
+        headers=_headers(),
+    )
+    assert resp_missing.status_code == 401
+    assert resp_wrong.status_code == 401
+    assert resp_missing.json()["detail"] == resp_wrong.json()["detail"]

--- a/tests/test_write_endpoint_auth.py
+++ b/tests/test_write_endpoint_auth.py
@@ -1,0 +1,322 @@
+"""Tests for P1 write-endpoint require_login enforcement."""
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("TESTING", "true")
+
+from api import runtime
+from api.main import app
+from api.routes import analyze as analyze_mod
+from api.routes import jobs as jobs_mod
+from src.services.user_store import reset_user_store
+
+API_KEY = os.getenv("GOVBUDGET_API_KEY", "change_me_to_a_strong_secret")
+ADMIN_PASSWORD = "AdminPass123"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    user_file = tmp_path / "users.json"
+    monkeypatch.setenv("USER_FILE", str(user_file))
+    monkeypatch.setenv("DEFAULT_ADMIN_PASSWORD", ADMIN_PASSWORD)
+    reset_user_store()
+    with TestClient(app) as test_client:
+        yield test_client
+    reset_user_store()
+
+
+def _headers(session_token: str | None = None) -> dict[str, str]:
+    h: dict[str, str] = {"X-API-Key": API_KEY}
+    if session_token:
+        h["X-Session-Token"] = session_token
+    return h
+
+
+def _login(client: TestClient, username: str, password: str) -> str:
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": username, "password": password},
+        headers=_headers(),
+    )
+    assert resp.status_code == 200, resp.text
+    return str(resp.json()["token"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers: create a regular user via admin
+# ---------------------------------------------------------------------------
+
+
+def _create_user(client: TestClient, admin_token: str, username: str, password: str) -> None:
+    resp = client.post(
+        "/api/users",
+        headers=_headers(admin_token),
+        json={"username": username, "password": password},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# No-session → 401 (TESTING=false to bypass the test shortcut)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteEndpointsRequireSession:
+    """Write endpoints must reject requests without a valid session."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_testing_bypass(self, monkeypatch):
+        monkeypatch.setenv("TESTING", "false")
+
+    def test_analyze_no_session_returns_401(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr(
+            runtime, "start_analysis", AsyncMock(return_value={"status": "ok"})
+        )
+        resp = client.post(
+            "/api/analyze/job-xxx",
+            headers=_headers(),
+            json={},
+        )
+        assert resp.status_code == 401
+
+    def test_associate_no_session_returns_401(self, client: TestClient):
+        resp = client.post(
+            "/api/jobs/job-xxx/associate",
+            headers=_headers(),
+            json={"org_id": "org-1"},
+        )
+        assert resp.status_code == 401
+
+    def test_reanalyze_no_session_returns_401(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr(
+            runtime, "reanalyze_job", AsyncMock(return_value={"status": "ok"})
+        )
+        resp = client.post(
+            "/api/jobs/job-xxx/reanalyze",
+            headers=_headers(),
+            json={},
+        )
+        assert resp.status_code == 401
+
+    def test_ignore_issue_no_session_returns_401(self, client: TestClient):
+        resp = client.post(
+            "/api/jobs/job-xxx/issues/ignore",
+            headers=_headers(),
+            json={"issue_id": "iss-1"},
+        )
+        assert resp.status_code == 401
+
+    def test_document_run_no_session_returns_401(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr(
+            runtime, "start_analysis", AsyncMock(return_value={"status": "ok"})
+        )
+        resp = client.post(
+            "/api/documents/version-xxx/run",
+            headers=_headers(),
+            json={},
+        )
+        assert resp.status_code == 401
+
+
+class TestWriteEndpointsInvalidSession:
+    """Write endpoints must reject requests with an invalid session token."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_testing_bypass(self, monkeypatch):
+        monkeypatch.setenv("TESTING", "false")
+
+    def test_analyze_invalid_token_returns_401(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr(
+            runtime, "start_analysis", AsyncMock(return_value={"status": "ok"})
+        )
+        resp = client.post(
+            "/api/analyze/job-xxx",
+            headers=_headers("bogus-token-xyz"),
+            json={},
+        )
+        assert resp.status_code == 401
+
+    def test_associate_invalid_token_returns_401(self, client: TestClient):
+        resp = client.post(
+            "/api/jobs/job-xxx/associate",
+            headers=_headers("bogus-token-xyz"),
+            json={"org_id": "org-1"},
+        )
+        assert resp.status_code == 401
+
+    def test_reanalyze_invalid_token_returns_401(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr(
+            runtime, "reanalyze_job", AsyncMock(return_value={"status": "ok"})
+        )
+        resp = client.post(
+            "/api/jobs/job-xxx/reanalyze",
+            headers=_headers("bogus-token-xyz"),
+            json={},
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Valid session → can access (does NOT require admin)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteEndpointsWithValidSession:
+    """Regular (non-admin) user can access these write endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_testing(self, monkeypatch):
+        monkeypatch.setenv("TESTING", "true")
+
+    def test_regular_user_can_trigger_analyze(
+        self, client: TestClient, monkeypatch
+    ):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "analyst", "AnalystPass1")
+        user_token = _login(client, "analyst", "AnalystPass1")
+
+        mock_start = AsyncMock(return_value={"job_id": "j1", "status": "started"})
+        monkeypatch.setattr(runtime, "start_analysis", mock_start)
+
+        resp = client.post(
+            "/api/analyze/j1",
+            headers=_headers(user_token),
+            json={"mode": "dual"},
+        )
+        assert resp.status_code == 200
+        mock_start.assert_called_once()
+
+    def test_regular_user_can_associate(
+        self, client: TestClient, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(runtime, "UPLOAD_ROOT", tmp_path)
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "editor", "EditorPass1")
+        user_token = _login(client, "editor", "EditorPass1")
+
+        dept_name = f"测试部门-{os.urandom(4).hex()}"
+        org_resp = client.post(
+            "/api/organizations",
+            headers=_headers(admin_token),
+            json={"name": dept_name, "level": "department"},
+        )
+        org_id = org_resp.json()["id"]
+
+        job_dir = tmp_path / "job-assoc-test"
+        job_dir.mkdir()
+        (job_dir / "test.pdf").write_bytes(b"%PDF-1.4\n%%EOF\n")
+
+        resp = client.post(
+            "/api/jobs/job-assoc-test/associate",
+            headers=_headers(user_token),
+            json={"org_id": org_id},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_regular_user_can_reanalyze(
+        self, client: TestClient, monkeypatch
+    ):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "reviewer", "ReviewerPass1")
+        user_token = _login(client, "reviewer", "ReviewerPass1")
+
+        mock_reanalyze = AsyncMock(
+            return_value={"job_id": "j2", "status": "queued"}
+        )
+        monkeypatch.setattr(runtime, "reanalyze_job", mock_reanalyze)
+
+        resp = client.post(
+            "/api/jobs/j2/reanalyze",
+            headers=_headers(user_token),
+            json={},
+        )
+        assert resp.status_code == 200
+
+    def test_regular_user_can_ignore_issue(self, client: TestClient, tmp_path):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "qa", "QaPass1")
+        user_token = _login(client, "qa", "QaPass1")
+
+        job_dir = tmp_path / "job-ignore-test"
+        job_dir.mkdir()
+        (job_dir / "test.pdf").write_bytes(b"%PDF-1.4\n%%EOF\n")
+        runtime.write_json_file(
+            job_dir / "status.json",
+            {
+                "status": "done",
+                "result": {
+                    "issues": {
+                        "all": [{"id": "iss-1", "title": "test issue"}],
+                        "error": [],
+                        "warn": [],
+                        "info": [],
+                    }
+                },
+            },
+        )
+        original_root = runtime.UPLOAD_ROOT
+        runtime.UPLOAD_ROOT = tmp_path
+        try:
+            resp = client.post(
+                "/api/jobs/job-ignore-test/issues/ignore",
+                headers=_headers(user_token),
+                json={"issue_id": "iss-1"},
+            )
+            assert resp.status_code == 200
+        finally:
+            runtime.UPLOAD_ROOT = original_root
+
+
+# ---------------------------------------------------------------------------
+# Admin-only endpoints still require admin (not just login)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminEndpointsStillProtected:
+    """Regular user must NOT access admin-only endpoints."""
+
+    def test_regular_user_cannot_batch_delete(
+        self, client: TestClient
+    ):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "viewer", "ViewerPass1")
+        user_token = _login(client, "viewer", "ViewerPass1")
+
+        resp = client.post(
+            "/api/jobs/batch-delete",
+            headers=_headers(user_token),
+            json={"job_ids": ["j1"]},
+        )
+        assert resp.status_code == 403
+
+    def test_regular_user_cannot_manage_users(self, client: TestClient):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "viewer2", "Viewer2Pass1")
+        user_token = _login(client, "viewer2", "Viewer2Pass1")
+
+        resp = client.post(
+            "/api/users",
+            headers=_headers(user_token),
+            json={"username": "hacker", "password": "HackPass1"},
+        )
+        assert resp.status_code == 403
+
+    def test_regular_user_cannot_manage_organizations(
+        self, client: TestClient
+    ):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "viewer3", "Viewer3Pass1")
+        user_token = _login(client, "viewer3", "Viewer3Pass1")
+
+        resp = client.post(
+            "/api/organizations",
+            headers=_headers(user_token),
+            json={"name": "非法部门", "level": "department"},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
## P0 — Security Hotfixes

- **Login brute-force protection**: per-user failure counter, 5-attempt lockout for 15 minutes, unified error messages to prevent user enumeration
- **Session secret enforcement**: production mode refuses to start if both USER_SESSION_SECRET and GOVBUDGET_API_KEY are empty (previously fell back to hardcoded dev-user-session-secret)
- **Dependency upgrades**: python-multipart 0.0.20 → 0.0.29 (fixes path traversal CVE-2026-24486), pypdf 5.0.1 → 6.12.2 (fixes 20 DoS CVEs)

## P1 — Reliability Hardening

- **Atomic status writes**: write_json_file now uses 	empfile.mkstemp + os.fsync + Path.replace to prevent corrupt status.json on crash or disk-full
- **Pipeline timeout**: entire analysis pipeline wrapped in syncio.wait_for(timeout=600s); timeout writes status=error with reason
- **Write endpoint auth**: 8 mutating endpoints (/api/analyze/*, /api/jobs/{id}/associate, /api/jobs/{id}/reanalyze, /api/jobs/{id}/issues/ignore, /api/documents/{id}/run) now require a valid user session, not just API key
- **FastAPI/Starlette upgrade**: astapi 0.116.2 → 0.121.3, starlette 0.48.0 → 0.49.3 (fixes CVE-2025-62727 Range header DoS)

## Verification

- uff check api src tests — passed
- pytest — 324 passed
- pip check — no broken requirements
- git diff --check origin/main...HEAD — no whitespace errors

## Remaining Risks

| CVE | Package | Current | Fix | Note |
|-----|---------|---------|-----|------|
| PYSEC-2026-161 | starlette | 0.49.3 | 1.0.1 | Requires FastAPI 0.122.0+ major jump |
| CVE-2026-45409 | idna | 3.13 | 3.15 | Low-priority DoS |