### PR TITLE
Enforce job owner access isolation

### DIFF
--- a/api/auth_utils.py
+++ b/api/auth_utils.py
@@ -36,3 +36,28 @@ def require_admin(request: Request) -> Tuple[Any, str, Dict[str, Any]]:
     if not bool(user.get("is_admin")):
         raise HTTPException(status_code=403, detail="admin privileges required")
     return store, token, user
+
+
+def user_can_access_job(user: Dict[str, Any], job_payload: Dict[str, Any]) -> bool:
+    """Return whether a logged-in user may access a job payload."""
+    if bool(user.get("is_admin")):
+        return True
+
+    owner = str(job_payload.get("created_by") or "").strip().lower()
+    if not owner:
+        # Legacy jobs did not record owners; keep them visible until migrated.
+        return True
+
+    username = str(user.get("username") or "").strip().lower()
+    return bool(username) and owner == username
+
+
+def require_job_access(
+    request: Request,
+    job_id: str,
+) -> Tuple[Any, str, Dict[str, Any], Dict[str, Any]]:
+    store, token, user = require_login(request)
+    payload = runtime.get_job_status_payload(job_id)
+    if not user_can_access_job(user, payload):
+        raise HTTPException(status_code=403, detail="job access denied")
+    return store, token, user, payload

--- a/api/routes/analyze.py
+++ b/api/routes/analyze.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, Request
 
 from api import runtime
-from api.auth_utils import require_login
+from api.auth_utils import require_job_access
 
 router = APIRouter()
 
@@ -17,7 +17,7 @@ router = APIRouter()
 @router.post("/analyze2/{job_id}")
 @router.post("/api/analyze2/{job_id}")
 async def analyze_job(job_id: str, request: Request):
-    require_login(request)
+    require_job_access(request, job_id)
     body: Optional[Dict[str, Any]] = None
     try:
         parsed = await request.json()
@@ -31,7 +31,7 @@ async def analyze_job(job_id: str, request: Request):
 
 @router.post("/api/documents/{version_id}/run")
 async def run_document(version_id: str, request: Request):
-    require_login(request)
+    require_job_access(request, version_id)
     body: Optional[Dict[str, Any]] = None
     try:
         parsed = await request.json()

--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import FileResponse, Response
 
 from api import runtime
-from api.auth_utils import require_login
+from api.auth_utils import require_job_access
 
 router = APIRouter()
 
@@ -114,7 +114,7 @@ def _render_preview_png(
 
 @router.get("/api/files/{job_id}/source")
 async def get_source_pdf(job_id: str, request: Request):
-    require_login(request)
+    require_job_access(request, job_id)
     pdf_path = _resolve_source_pdf(job_id)
     return FileResponse(str(pdf_path), media_type="application/pdf", filename=pdf_path.name)
 
@@ -128,7 +128,7 @@ async def get_source_preview(
     padding: float = Query(default=24.0, ge=0.0, le=200.0),
     scale: float = Query(default=2.0, ge=0.5, le=4.0),
 ):
-    require_login(request)
+    require_job_access(request, job_id)
     pdf_path = _resolve_source_pdf(job_id)
     parsed_bbox = _parse_bbox_query(bbox)
     png_bytes = _render_preview_png(

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from api import runtime
-from api.auth_utils import require_admin, require_login
+from api.auth_utils import require_admin, require_job_access, require_login, user_can_access_job
 from api.routes.organizations import clear_department_stats_cache
 from src.services.analysis_result_store import (
     get_persisted_analysis_job_detail,
@@ -34,7 +34,7 @@ async def list_jobs(
     limit: int | None = Query(default=None, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ):
-    require_login(request)
+    _, _, user = require_login(request)
     job_dirs = runtime.iter_job_dirs()
 
     def _quick_ts(job_dir):
@@ -47,11 +47,20 @@ async def list_jobs(
             return 0.0
 
     if limit is None and offset == 0:
-        jobs = [runtime.collect_job_summary(job_dir) for job_dir in job_dirs]
+        jobs = [
+            summary
+            for job_dir in job_dirs
+            for summary in [runtime.collect_job_summary(job_dir)]
+            if user_can_access_job(user, summary)
+        ]
         jobs.sort(key=lambda x: x.get("ts", 0), reverse=True)
         return jobs
 
-    sorted_dirs = sorted(job_dirs, key=_quick_ts, reverse=True)
+    sorted_dirs = [
+        job_dir
+        for job_dir in sorted(job_dirs, key=_quick_ts, reverse=True)
+        if user_can_access_job(user, runtime.collect_job_summary(job_dir))
+    ]
     total = len(sorted_dirs)
     if limit is None:
         selected_dirs = sorted_dirs[offset:]
@@ -266,14 +275,13 @@ async def batch_delete_jobs(request: Request):
 @router.get("/jobs/{job_id}/status")
 @router.get("/api/jobs/{job_id}/status")
 async def get_job_status(job_id: str, request: Request):
-    require_login(request)
-    return runtime.get_job_status_payload(job_id)
+    _, _, _, payload = require_job_access(request, job_id)
+    return payload
 
 
 @router.get("/api/jobs/{job_id}")
 async def get_job_detail(job_id: str, request: Request):
-    require_login(request)
-    payload = runtime.get_job_status_payload(job_id)
+    _, _, _, payload = require_job_access(request, job_id)
     payload.setdefault("job_id", job_id)
     try:
         payload["filename"] = runtime.find_first_pdf(runtime.UPLOAD_ROOT / job_id).name
@@ -284,13 +292,13 @@ async def get_job_detail(job_id: str, request: Request):
 
 @router.get("/api/jobs/{job_id}/review")
 async def get_job_review(job_id: str, request: Request):
-    require_login(request)
+    require_job_access(request, job_id)
     return runtime.get_job_review_payload(job_id)
 
 
 @router.get("/api/jobs/{job_id}/structured-ingest")
 async def get_job_structured_ingest(job_id: str, request: Request):
-    require_login(request)
+    require_job_access(request, job_id)
     return runtime.get_job_review_payload(job_id)
 
 
@@ -300,7 +308,7 @@ async def get_job_org_suggestions(
     job_id: str,
     top_n: int = Query(default=5, ge=1, le=20),
 ):
-    require_login(request)
+    require_job_access(request, job_id)
     job_dir = runtime.UPLOAD_ROOT / job_id
     if not job_dir.exists():
         raise HTTPException(status_code=404, detail="job_id does not exist")
@@ -369,7 +377,7 @@ async def delete_job(job_id: str, request: Request):
 
 @router.post("/api/jobs/{job_id}/associate")
 async def associate_job(job_id: str, request: Request):
-    require_login(request)
+    require_job_access(request, job_id)
     body = await request.json()
     org_id = (body or {}).get("org_id")
     if not org_id:
@@ -392,7 +400,7 @@ async def associate_job(job_id: str, request: Request):
 
 @router.post("/api/jobs/{job_id}/reanalyze")
 async def reanalyze_job(job_id: str, request: Request):
-    require_login(request)
+    require_job_access(request, job_id)
     try:
         body = await request.json()
     except Exception:
@@ -402,7 +410,7 @@ async def reanalyze_job(job_id: str, request: Request):
 
 @router.post("/api/jobs/{job_id}/issues/ignore")
 async def ignore_job_issue(job_id: str, request: Request):
-    require_login(request)
+    require_job_access(request, job_id)
     try:
         body = await request.json()
     except Exception:

--- a/api/routes/reports.py
+++ b/api/routes/reports.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import FileResponse, Response
 
 from api import runtime
-from api.auth_utils import require_login
+from api.auth_utils import require_job_access, require_login
 from src.utils.issue_display import build_issue_display
 
 router = APIRouter()
@@ -1076,8 +1076,7 @@ async def download_report(
     job_id: str,
     format: str = Query(default="pdf", pattern="^(pdf|json|csv|docx)$"),
 ):
-    require_login(request)
-    status_payload = runtime.get_job_status_payload(job_id)
+    _, _, _, status_payload = require_job_access(request, job_id)
     issues = _extract_issues(status_payload)
 
     if format == "json":
@@ -1158,7 +1157,7 @@ async def download_reports_batch(body: Dict[str, Any], request: Request):
     with zipfile.ZipFile(archive_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
         for job_id in job_ids:
             try:
-                status_payload = runtime.get_job_status_payload(job_id)
+                _, _, _, status_payload = require_job_access(request, job_id)
                 issues = _extract_issues(status_payload)
                 annotated_pdf = _create_annotated_pdf(job_id, status_payload, issues)
                 report_pdf = annotated_pdf or _resolve_report_pdf(job_id, status_payload)
@@ -1177,6 +1176,8 @@ async def download_reports_batch(body: Dict[str, Any], request: Request):
                     }
                 )
             except HTTPException as exc:
+                if exc.status_code in {401, 403}:
+                    raise
                 failed.append(
                     {
                         "job_id": job_id,

--- a/api/routes/upload.py
+++ b/api/routes/upload.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 
 from api import runtime
+from api.auth_utils import require_login
 from api.routes.organizations import clear_department_stats_cache
 from src.services.org_matcher import get_org_matcher
 
@@ -212,6 +213,7 @@ async def _handle_upload(
     selected_org: Optional[str] = None,
     fiscal_year: Optional[str] = None,
     doc_type: Optional[str] = None,
+    created_by: Optional[str] = None,
 ) -> dict:
     selected_org = _clean_optional_text(selected_org)
     fiscal_year = _clean_optional_text(fiscal_year)
@@ -229,6 +231,7 @@ async def _handle_upload(
             "organization_match_confidence": 1.0 if selected_org else None,
             "fiscal_year": fiscal_year,
             "doc_type": doc_type,
+            "created_by": created_by,
         },
     )
 
@@ -280,12 +283,14 @@ async def _handle_upload(
 
 @router.post("/api/documents/preflight")
 async def preflight_document(
+    request: Request,
     file: UploadFile = File(...),
     fiscal_year: Optional[str] = Form(None),
     doc_type: Optional[str] = Form(None),
     api_key: str = Depends(runtime.verify_api_key),
 ):
     _ = api_key
+    require_login(request)
     payload = _inspect_document_preflight(
         filename=file.filename or "",
         preferred_year=_clean_optional_text(fiscal_year),
@@ -297,15 +302,18 @@ async def preflight_document(
 
 @router.post("/upload")
 async def upload_pdf(
+    request: Request,
     file: UploadFile = File(...),
     api_key: str = Depends(runtime.verify_api_key),
 ):
     _ = api_key
-    return await _handle_upload(file)
+    _, _, user = require_login(request)
+    return await _handle_upload(file, created_by=str(user.get("username") or ""))
 
 
 @router.post("/api/documents/upload")
 async def upload_document(
+    request: Request,
     file: UploadFile = File(...),
     org_unit_id: Optional[str] = Form(None),
     org_id: Optional[str] = Form(None),
@@ -314,9 +322,11 @@ async def upload_document(
     api_key: str = Depends(runtime.verify_api_key),
 ):
     _ = api_key
+    _, _, user = require_login(request)
     return await _handle_upload(
         file,
         selected_org=org_unit_id or org_id,
         fiscal_year=fiscal_year,
         doc_type=doc_type,
+        created_by=str(user.get("username") or ""),
     )

--- a/api/runtime.py
+++ b/api/runtime.py
@@ -99,6 +99,7 @@ JOB_STATUS_CONTEXT_KEYS = (
     "doc_type",
     "report_year",
     "report_kind",
+    "created_by",
 )
 ACTIVE_ANALYSIS_STATUSES = {"queued", "processing", "running"}
 REANALYZE_EPHEMERAL_FILES = {
@@ -1782,6 +1783,7 @@ def collect_job_summary(job_dir: Path) -> Dict[str, Any]:
         "organization_name": status_data.get("organization_name"),
         "organization_match_type": status_data.get("organization_match_type"),
         "organization_match_confidence": status_data.get("organization_match_confidence"),
+        "created_by": status_data.get("created_by"),
     }
 
     _JOB_SUMMARY_CACHE[job_dir.name] = {
@@ -2114,7 +2116,7 @@ async def store_upload_file(
     if metadata:
         status_payload.update({key: value for key, value in metadata.items() if value is not None})
     write_json_file(job_dir / "status.json", status_payload)
-    return payload
+    return {**payload, **extract_job_status_context(status_payload)}
 
 
 def get_job_status_payload(job_id: str) -> Dict[str, Any]:
@@ -2313,9 +2315,7 @@ async def start_analysis(
         "ts": time.time(),
     }
     try:
-        status_file.write_text(
-            json.dumps(payload, ensure_ascii=False), encoding="utf-8"
-        )
+        write_json_file(status_file, payload)
         await persist_analysis_job_snapshot(payload)
         queue = _job_queue
         dispatch = "local_queue"

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -791,7 +791,11 @@ def test_batch_delete_endpoint_removes_jobs(monkeypatch, tmp_path: Path):
     assert not (tmp_path / "job-delete-2").exists()
 
 
-def test_job_issue_ignore_endpoint_returns_filtered_status(monkeypatch):
+def test_job_issue_ignore_endpoint_returns_filtered_status(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runtime, "UPLOAD_ROOT", tmp_path)
+    job_dir = tmp_path / "job-issue"
+    job_dir.mkdir(parents=True, exist_ok=True)
+    runtime.write_json_file(job_dir / "status.json", {"job_id": "job-issue", "status": "done"})
     client = TestClient(app)
 
     def _fake_ignore(job_id: str, issue_id: str):

--- a/tests/test_write_endpoint_auth.py
+++ b/tests/test_write_endpoint_auth.py
@@ -87,6 +87,14 @@ def _create_job(upload_root: Path, job_id: str = "job-read-test") -> Path:
     return job_dir
 
 
+def _create_owned_job(upload_root: Path, job_id: str, username: str) -> Path:
+    job_dir = _create_job(upload_root, job_id)
+    payload = runtime.read_json_file(job_dir / "status.json", default={})
+    payload["created_by"] = username
+    runtime.write_json_file(job_dir / "status.json", payload)
+    return job_dir
+
+
 # ---------------------------------------------------------------------------
 # No-session → 401 (TESTING=false to bypass the test shortcut)
 # ---------------------------------------------------------------------------
@@ -145,6 +153,30 @@ class TestWriteEndpointsRequireSession:
             "/api/documents/version-xxx/run",
             headers=_headers(),
             json={},
+        )
+        assert resp.status_code == 401
+
+    def test_document_preflight_no_session_returns_401(self, client: TestClient):
+        resp = client.post(
+            "/api/documents/preflight",
+            headers=_headers(),
+            files={"file": ("sample.pdf", b"%PDF-1.4\n%%EOF\n", "application/pdf")},
+        )
+        assert resp.status_code == 401
+
+    def test_document_upload_no_session_returns_401(self, client: TestClient):
+        resp = client.post(
+            "/api/documents/upload",
+            headers=_headers(),
+            files={"file": ("sample.pdf", b"%PDF-1.4\n%%EOF\n", "application/pdf")},
+        )
+        assert resp.status_code == 401
+
+    def test_legacy_upload_no_session_returns_401(self, client: TestClient):
+        resp = client.post(
+            "/upload",
+            headers=_headers(),
+            files={"file": ("sample.pdf", b"%PDF-1.4\n%%EOF\n", "application/pdf")},
         )
         assert resp.status_code == 401
 
@@ -264,6 +296,7 @@ class TestWriteEndpointsWithValidSession:
         admin_token = _login(client, "admin", ADMIN_PASSWORD)
         _create_user(client, admin_token, "analyst", "AnalystPass1")
         user_token = _login(client, "analyst", "AnalystPass1")
+        _create_owned_job(runtime.UPLOAD_ROOT, "j1", "analyst")
 
         mock_start = AsyncMock(return_value={"job_id": "j1", "status": "started"})
         monkeypatch.setattr(runtime, "start_analysis", mock_start)
@@ -310,6 +343,7 @@ class TestWriteEndpointsWithValidSession:
         admin_token = _login(client, "admin", ADMIN_PASSWORD)
         _create_user(client, admin_token, "reviewer", "ReviewerPass1")
         user_token = _login(client, "reviewer", "ReviewerPass1")
+        _create_owned_job(runtime.UPLOAD_ROOT, "j2", "reviewer")
 
         mock_reanalyze = AsyncMock(
             return_value={"job_id": "j2", "status": "queued"}
@@ -378,6 +412,107 @@ class TestWriteEndpointsWithValidSession:
         source = client.get("/api/files/job-read-test/source", headers=_headers(user_token))
         assert source.status_code == 200
         assert source.headers["content-type"].startswith("application/pdf")
+
+
+class TestJobOwnerIsolation:
+    """Regular users must not access jobs owned by another user."""
+
+    def test_jobs_list_hides_other_users_owned_jobs(self, client: TestClient):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "alice", "AlicePass1")
+        _create_user(client, admin_token, "bob", "BobPass1")
+        alice_token = _login(client, "alice", "AlicePass1")
+        bob_token = _login(client, "bob", "BobPass1")
+        _create_owned_job(runtime.UPLOAD_ROOT, "alice-job", "alice")
+        _create_owned_job(runtime.UPLOAD_ROOT, "bob-job", "bob")
+
+        alice_jobs = client.get("/api/jobs", headers=_headers(alice_token)).json()
+        bob_jobs = client.get("/api/jobs", headers=_headers(bob_token)).json()
+        admin_jobs = client.get("/api/jobs", headers=_headers(admin_token)).json()
+
+        assert {item["job_id"] for item in alice_jobs} == {"alice-job"}
+        assert {item["job_id"] for item in bob_jobs} == {"bob-job"}
+        assert {"alice-job", "bob-job"}.issubset({item["job_id"] for item in admin_jobs})
+
+    def test_regular_user_cannot_read_other_users_job_detail(self, client: TestClient):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "owner", "OwnerPass1")
+        _create_user(client, admin_token, "intruder", "IntruderPass1")
+        intruder_token = _login(client, "intruder", "IntruderPass1")
+        _create_owned_job(runtime.UPLOAD_ROOT, "owned-job", "owner")
+
+        resp = client.get("/api/jobs/owned-job", headers=_headers(intruder_token))
+
+        assert resp.status_code == 403
+
+    def test_regular_user_cannot_download_other_users_report_or_source(
+        self,
+        client: TestClient,
+    ):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "owner2", "Owner2Pass1")
+        _create_user(client, admin_token, "intruder2", "Intruder2Pass1")
+        intruder_token = _login(client, "intruder2", "Intruder2Pass1")
+        _create_owned_job(runtime.UPLOAD_ROOT, "owned-download-job", "owner2")
+
+        report = client.get(
+            "/api/reports/download?job_id=owned-download-job&format=json",
+            headers=_headers(intruder_token),
+        )
+        source = client.get(
+            "/api/files/owned-download-job/source",
+            headers=_headers(intruder_token),
+        )
+
+        assert report.status_code == 403
+        assert source.status_code == 403
+
+    def test_regular_user_cannot_batch_download_other_users_report(self, client: TestClient):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "owner_batch", "OwnerBatch1")
+        _create_user(client, admin_token, "intruder_batch", "IntruderBatch1")
+        intruder_token = _login(client, "intruder_batch", "IntruderBatch1")
+        _create_owned_job(runtime.UPLOAD_ROOT, "owned-batch-job", "owner_batch")
+
+        resp = client.post(
+            "/api/reports/download-batch",
+            headers=_headers(intruder_token),
+            json={"job_ids": ["owned-batch-job"]},
+        )
+
+        assert resp.status_code == 403
+
+    def test_regular_user_cannot_mutate_other_users_job(self, client: TestClient):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "owner3", "Owner3Pass1")
+        _create_user(client, admin_token, "intruder3", "Intruder3Pass1")
+        intruder_token = _login(client, "intruder3", "Intruder3Pass1")
+        _create_owned_job(runtime.UPLOAD_ROOT, "owned-mutate-job", "owner3")
+
+        reanalyze = client.post(
+            "/api/jobs/owned-mutate-job/reanalyze",
+            headers=_headers(intruder_token),
+            json={},
+        )
+        ignore = client.post(
+            "/api/jobs/owned-mutate-job/issues/ignore",
+            headers=_headers(intruder_token),
+            json={"issue_id": "iss-1"},
+        )
+
+        assert reanalyze.status_code == 403
+        assert ignore.status_code == 403
+
+    def test_legacy_unowned_jobs_remain_visible_to_regular_users(self, client: TestClient):
+        admin_token = _login(client, "admin", ADMIN_PASSWORD)
+        _create_user(client, admin_token, "legacy_reader", "LegacyPass1")
+        user_token = _login(client, "legacy_reader", "LegacyPass1")
+        _create_job(runtime.UPLOAD_ROOT, "legacy-job")
+
+        resp = client.get("/api/jobs/legacy-job", headers=_headers(user_token))
+
+        assert resp.status_code == 200
+        assert resp.json()["job_id"] == "legacy-job"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Record `created_by` on authenticated uploads and preserve it through job status transitions.
- Enforce owner-aware access checks for job detail/status/review/structured-ingest/org-suggestions, source/preview downloads, report downloads, analyze/reanalyze/associate/ignore, and batch report download.
- Filter `/api/jobs` results for regular users while admins continue to see all jobs.
- Require user session auth for upload and document preflight endpoints.
- Add regression tests for no-session access, cross-user isolation, legacy unowned jobs, and batch download denial.

## Validation
- `ruff check api src tests`
- `mypy api src tests`
- `pytest` -> 348 passed, 1 Starlette TestClient deprecation warning
- `npm --prefix app run build`
- `npm --prefix app run test:e2e` -> 12 passed
- `git diff --check`

## Notes
- This PR implements owner-based job isolation for newly uploaded jobs.
- Legacy jobs without `created_by` remain visible to regular users until a migration assigns owners or the system switches to fail-closed behavior.
- Organization/department membership-based access control is left for a follow-up because the current user model does not yet define organization binding.