### PR TITLE
Add organization scoped user access

### DIFF
--- a/api/auth_utils.py
+++ b/api/auth_utils.py
@@ -38,9 +38,75 @@ def require_admin(request: Request) -> Tuple[Any, str, Dict[str, Any]]:
     return store, token, user
 
 
+def _user_org_scope(user: Dict[str, Any]) -> set[str]:
+    raw_scope = user.get("organization_ids")
+    if not isinstance(raw_scope, list):
+        return set()
+    return {str(item or "").strip() for item in raw_scope if str(item or "").strip()}
+
+
+def _job_organization_id(job_payload: Dict[str, Any]) -> str:
+    direct_org_id = str(job_payload.get("organization_id") or "").strip()
+    if direct_org_id:
+        return direct_org_id
+
+    job_id = str(job_payload.get("job_id") or "").strip()
+    if not job_id:
+        return ""
+
+    try:
+        storage = runtime.require_org_storage()
+        link = storage.get_job_org(job_id)
+    except Exception:
+        return ""
+    if link is None:
+        return ""
+    return str(getattr(link, "org_id", "") or "").strip()
+
+
+def user_can_access_org(user: Dict[str, Any], org_id: str) -> bool:
+    """Return whether a logged-in user may access an organization subtree."""
+    if bool(user.get("is_admin")):
+        return True
+
+    target_org_id = str(org_id or "").strip()
+    if not target_org_id:
+        return False
+
+    allowed_org_ids = _user_org_scope(user)
+    if not allowed_org_ids:
+        return False
+    if target_org_id in allowed_org_ids:
+        return True
+
+    try:
+        storage = runtime.require_org_storage()
+    except Exception:
+        return False
+
+    current = storage.get_by_id(target_org_id)
+    seen: set[str] = set()
+    while current is not None:
+        current_id = str(getattr(current, "id", "") or "").strip()
+        if not current_id or current_id in seen:
+            return False
+        if current_id in allowed_org_ids:
+            return True
+        seen.add(current_id)
+        parent_id = getattr(current, "parent_id", None)
+        if not parent_id:
+            return False
+        current = storage.get_by_id(str(parent_id))
+    return False
+
+
 def user_can_access_job(user: Dict[str, Any], job_payload: Dict[str, Any]) -> bool:
     """Return whether a logged-in user may access a job payload."""
     if bool(user.get("is_admin")):
+        return True
+
+    job_org_id = _job_organization_id(job_payload)
+    if job_org_id and user_can_access_org(user, job_org_id):
         return True
 
     owner = str(job_payload.get("created_by") or "").strip().lower()

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -17,6 +17,36 @@ def _coerce_bool(value: Any, field_name: str) -> bool:
     raise HTTPException(status_code=400, detail=f"{field_name} must be boolean")
 
 
+def _coerce_organization_ids(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise HTTPException(status_code=400, detail="organization_ids must be a list")
+
+    result: list[str] = []
+    seen = set()
+    for item in value:
+        text = str(item or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _validate_organization_ids_exist(organization_ids: list[str]) -> None:
+    if not organization_ids:
+        return
+
+    storage = runtime.require_org_storage()
+    missing = [org_id for org_id in organization_ids if storage.get_by_id(org_id) is None]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown organization_ids: {', '.join(missing)}",
+        )
+
+
 def _coerce_password(value: Any, required: bool = False) -> Optional[str]:
     if value is None:
         if required:
@@ -148,9 +178,16 @@ async def create_user(request: Request):
 
     raw_is_admin = body.get("is_admin", False)
     is_admin = _coerce_bool(raw_is_admin, "is_admin") if "is_admin" in body else False
+    organization_ids = _coerce_organization_ids(body.get("organization_ids"))
+    _validate_organization_ids_exist(organization_ids)
 
     try:
-        user = store.add_user(username=username, password=password, is_admin=is_admin)
+        user = store.add_user(
+            username=username,
+            password=password,
+            is_admin=is_admin,
+            organization_ids=organization_ids,
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -165,14 +202,23 @@ async def update_user(username: str, request: Request):
     is_admin: Optional[bool] = None
     is_active: Optional[bool] = None
     password: Optional[str] = None
+    organization_ids: Optional[list[str]] = None
     if "is_admin" in body:
         is_admin = _coerce_bool(body.get("is_admin"), "is_admin")
     if "is_active" in body:
         is_active = _coerce_bool(body.get("is_active"), "is_active")
     if "password" in body:
         password = _coerce_password(body.get("password"), required=True)
+    if "organization_ids" in body:
+        organization_ids = _coerce_organization_ids(body.get("organization_ids"))
+        _validate_organization_ids_exist(organization_ids)
 
-    if is_admin is None and is_active is None and password is None:
+    if (
+        is_admin is None
+        and is_active is None
+        and password is None
+        and organization_ids is None
+    ):
         raise HTTPException(status_code=400, detail="no update fields provided")
 
     try:
@@ -181,6 +227,7 @@ async def update_user(username: str, request: Request):
             is_admin=is_admin,
             is_active=is_active,
             password=password,
+            organization_ids=organization_ids,
         )
     except KeyError:
         raise HTTPException(status_code=404, detail="user not found")

--- a/api/routes/organizations.py
+++ b/api/routes/organizations.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Dict, List, Tuple
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 
-from api.auth_utils import require_admin
+from api.auth_utils import require_admin, require_login, user_can_access_job, user_can_access_org
 from api import runtime
 from src.services.audit_log import append_audit_event
 
@@ -172,6 +172,55 @@ def _build_aggregated_org_stats(storage) -> Dict[str, Dict[str, Any]]:
     return aggregated_stats
 
 
+def _build_user_visible_aggregated_org_stats(
+    storage,
+    user: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    direct_stats: Dict[str, Dict[str, Any]] = {}
+
+    for org in storage.get_all():
+        valid_job_ids, _ = _split_existing_job_ids(
+            storage.get_org_jobs(org.id, include_children=False)
+        )
+        job_count = 0
+        issue_total = 0
+        for job_id in valid_job_ids:
+            status_payload = runtime.get_job_status_payload(job_id)
+            if not user_can_access_job(user, status_payload):
+                continue
+            summary = runtime.collect_job_summary(runtime.UPLOAD_ROOT / job_id)
+            job_count += 1
+            issue_total += _extract_summary_issue_total(summary)
+        direct_stats[org.id] = {
+            "job_count": job_count,
+            "issue_total": issue_total,
+            "has_issues": issue_total > 0,
+        }
+
+    aggregated_stats: Dict[str, Dict[str, Any]] = {}
+
+    def walk(org_id: str) -> Dict[str, Any]:
+        current = dict(
+            direct_stats.get(
+                org_id,
+                {"job_count": 0, "issue_total": 0, "has_issues": False},
+            )
+        )
+        for child in storage.get_children(org_id):
+            child_stats = walk(child.id)
+            current["job_count"] += int(child_stats.get("job_count") or 0)
+            current["issue_total"] += int(child_stats.get("issue_total") or 0)
+        current["has_issues"] = bool(current["issue_total"] > 0)
+        aggregated_stats[org_id] = current
+        return current
+
+    for org in storage.get_all():
+        if org.id not in aggregated_stats:
+            walk(org.id)
+
+    return aggregated_stats
+
+
 def _apply_tree_stats(
     nodes: List[Dict[str, Any]],
     stats_by_org: Dict[str, Dict[str, Any]],
@@ -186,18 +235,41 @@ def _apply_tree_stats(
             _apply_tree_stats(children, stats_by_org)
 
 
+def _filter_tree_for_user(nodes: List[Dict[str, Any]], user: Dict[str, Any]) -> List[Dict[str, Any]]:
+    if bool(user.get("is_admin")):
+        return nodes
+
+    filtered: List[Dict[str, Any]] = []
+    for node in nodes:
+        children = node.get("children")
+        child_nodes = _filter_tree_for_user(children, user) if isinstance(children, list) else []
+        node_id = str(node.get("id") or "").strip()
+        if user_can_access_org(user, node_id) or child_nodes:
+            next_node = dict(node)
+            next_node["children"] = child_nodes
+            filtered.append(next_node)
+    return filtered
+
+
 @router.get("/api/organizations")
 async def get_organizations(
+    request: Request,
     stats: str = Query(
         default="aggregated",
         description="Use 'none' for a lightweight navigation tree without job statistics.",
     ),
 ):
+    _, _, user = require_login(request)
     storage = runtime.require_org_storage()
     tree = [runtime.to_dict(node) for node in storage.get_tree()]
+    tree = _filter_tree_for_user(tree, user)
     if str(stats or "").lower() not in {"none", "false", "0", "off"}:
-        _apply_tree_stats(tree, _build_aggregated_org_stats(storage))
-    return {"tree": tree, "total": len(storage.get_all())}
+        if bool(user.get("is_admin")):
+            stats_by_org = _build_aggregated_org_stats(storage)
+        else:
+            stats_by_org = _build_user_visible_aggregated_org_stats(storage, user)
+        _apply_tree_stats(tree, stats_by_org)
+    return {"tree": tree, "total": len(tree) if not bool(user.get("is_admin")) else len(storage.get_all())}
 
 
 @router.post("/api/organizations")
@@ -330,10 +402,13 @@ async def get_delete_preview(org_id: str, request: Request):
 
 
 @router.get("/api/organizations/list")
-async def get_organizations_list():
+async def get_organizations_list(request: Request):
+    _, _, user = require_login(request)
     storage = runtime.require_org_storage()
     organizations = []
     for org in storage.get_all():
+        if not user_can_access_org(user, org.id):
+            continue
         level_name = org.level
         if runtime.OrganizationLevel is not None:
             level_name = runtime.OrganizationLevel.get_display_name(org.level)
@@ -350,11 +425,14 @@ async def get_organizations_list():
 
 
 @router.get("/api/departments")
-async def get_departments():
+async def get_departments(request: Request):
+    _, _, user = require_login(request)
     storage = runtime.require_org_storage()
     aggregated_stats = _build_aggregated_org_stats(storage)
     departments = []
     for org in storage.get_departments():
+        if not user_can_access_org(user, org.id):
+            continue
         payload = runtime.to_dict(org)
         stats = aggregated_stats.get(org.id, {})
         payload["job_count"] = int(stats.get("job_count") or 0)
@@ -364,22 +442,32 @@ async def get_departments():
 
 
 @router.get("/api/departments/{dept_id}/units")
-async def get_units_by_department(dept_id: str):
+async def get_units_by_department(dept_id: str, request: Request):
+    _, _, user = require_login(request)
     storage = runtime.require_org_storage()
     department = storage.get_by_id(dept_id)
     if department is None or getattr(department, "level", None) != "department":
         raise HTTPException(status_code=404, detail="department not found")
+    if not user_can_access_org(user, dept_id):
+        raise HTTPException(status_code=403, detail="organization access denied")
 
-    units = [runtime.to_dict(org) for org in storage.get_units_by_department(dept_id)]
+    units = [
+        runtime.to_dict(org)
+        for org in storage.get_units_by_department(dept_id)
+        if user_can_access_org(user, org.id)
+    ]
     return {"units": units, "total": len(units)}
 
 
 @router.get("/api/departments/{dept_id}/stats")
-async def get_department_stats(dept_id: str):
+async def get_department_stats(dept_id: str, request: Request):
+    _, _, user = require_login(request)
     storage = runtime.require_org_storage()
     department = storage.get_by_id(dept_id)
     if department is None or getattr(department, "level", None) != "department":
         raise HTTPException(status_code=404, detail="department not found")
+    if not user_can_access_org(user, dept_id):
+        raise HTTPException(status_code=403, detail="organization access denied")
 
     now = time.time()
     if _DEPT_STATS_CACHE_TTL_SECONDS > 0:
@@ -464,6 +552,7 @@ async def import_organizations(
 
 @router.get("/api/organizations/{org_id}/jobs")
 async def get_organization_jobs(
+    request: Request,
     org_id: str,
     include_children: bool = Query(
         default=False,
@@ -472,14 +561,22 @@ async def get_organization_jobs(
     limit: int | None = Query(default=None, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ):
+    _, _, user = require_login(request)
     storage = runtime.require_org_storage()
     org = storage.get_by_id(org_id)
     if org is None:
         raise HTTPException(status_code=404, detail="organization not found")
+    if not user_can_access_org(user, org_id):
+        raise HTTPException(status_code=403, detail="organization access denied")
 
     job_ids, _ = _split_existing_job_ids(
         storage.get_org_jobs(org_id, include_children=include_children)
     )
+    job_ids = [
+        job_id
+        for job_id in job_ids
+        if user_can_access_job(user, runtime.get_job_status_payload(job_id))
+    ]
     total = len(job_ids)
 
     def _quick_ts(job_id: str) -> float:

--- a/app/app/api/departments/[dept_id]/stats/route.ts
+++ b/app/app/api/departments/[dept_id]/stats/route.ts
@@ -38,6 +38,7 @@ export async function GET(
     if (response.ok) {
       return NextResponse.json(data, { status: response.status });
     }
+    return NextResponse.json(data, { status: response.status });
   } catch (error) {
     console.error("Failed to fetch department stats:", error);
   }

--- a/app/app/api/departments/[dept_id]/units/route.ts
+++ b/app/app/api/departments/[dept_id]/units/route.ts
@@ -40,6 +40,7 @@ export async function GET(
     if (response.ok) {
       return NextResponse.json(data, { status: response.status });
     }
+    return NextResponse.json(data, { status: response.status });
   } catch (error) {
     console.error("Failed to fetch department units:", error);
   }

--- a/app/app/api/departments/route.ts
+++ b/app/app/api/departments/route.ts
@@ -30,6 +30,7 @@ export async function GET() {
     if (response.ok) {
       return NextResponse.json(data, { status: response.status });
     }
+    return NextResponse.json(data, { status: response.status });
   } catch (error) {
     if (process.env.NODE_ENV !== "production") {
       console.error("Failed to fetch departments:", error);

--- a/app/app/api/organizations/[org_id]/jobs/route.ts
+++ b/app/app/api/organizations/[org_id]/jobs/route.ts
@@ -65,6 +65,7 @@ export async function GET(
         status: res.status,
         bodyPreview: text.slice(0, 500),
       });
+      return NextResponse.json(data ?? { detail: "backend request failed", jobs: [] }, { status: res.status });
     } else {
       console.error("Backend organization jobs returned unexpected payload:", {
         orgId: (await params).org_id,

--- a/app/app/api/organizations/list/route.ts
+++ b/app/app/api/organizations/list/route.ts
@@ -56,6 +56,7 @@ export async function GET() {
       }
       return NextResponse.json(data, { status: response.status });
     }
+    return NextResponse.json(data, { status: response.status });
   } catch (error) {
     if (process.env.NODE_ENV !== "production") {
       console.error("Failed to fetch organizations list:", error);

--- a/app/app/api/organizations/route.ts
+++ b/app/app/api/organizations/route.ts
@@ -66,6 +66,7 @@ export async function GET(request: Request) {
       }
       return NextResponse.json(data, { status: response.status });
     }
+    return NextResponse.json(data, { status: response.status });
   } catch (error) {
     if (process.env.NODE_ENV !== "production") {
       console.error("Failed to fetch organizations:", error);

--- a/app/app/api/users/[username]/route.ts
+++ b/app/app/api/users/[username]/route.ts
@@ -48,6 +48,23 @@ function parsePasswordField(value: unknown): string {
   return value;
 }
 
+function parseOrganizationIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    throw new LocalAuthError(400, "organization_ids must be a list");
+  }
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    const text = String(item ?? "").trim();
+    if (!text || seen.has(text)) {
+      continue;
+    }
+    seen.add(text);
+    result.push(text);
+  }
+  return result;
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ username: string }> }
@@ -65,7 +82,7 @@ export async function PATCH(
         return forbiddenResponse();
       }
 
-      const updates: { is_admin?: boolean; is_active?: boolean; password?: string } = {};
+      const updates: { is_admin?: boolean; is_active?: boolean; password?: string; organization_ids?: string[] } = {};
       try {
         if ("is_admin" in body) {
           updates.is_admin = parseBooleanField(body.is_admin, "is_admin");
@@ -75,6 +92,9 @@ export async function PATCH(
         }
         if ("password" in body) {
           updates.password = parsePasswordField(body.password);
+        }
+        if ("organization_ids" in body) {
+          updates.organization_ids = parseOrganizationIds(body.organization_ids);
         }
         const user = await updateLocalUser((await params).username, updates);
         return NextResponse.json(user, { status: 200 });

--- a/app/app/api/users/route.ts
+++ b/app/app/api/users/route.ts
@@ -44,6 +44,23 @@ function parseBooleanField(
   return value;
 }
 
+function parseOrganizationIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    throw new LocalAuthError(400, "organization_ids must be a list");
+  }
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    const text = String(item ?? "").trim();
+    if (!text || seen.has(text)) {
+      continue;
+    }
+    seen.add(text);
+    result.push(text);
+  }
+  return result;
+}
+
 export async function GET() {
   const sessionToken = await readSessionToken();
   if (!sessionToken) {
@@ -94,6 +111,8 @@ export async function POST(request: NextRequest) {
           password: typeof body?.password === "string" ? body.password : "",
           is_admin:
             "is_admin" in body ? parseBooleanField(body.is_admin, "is_admin") : false,
+          organization_ids:
+            "organization_ids" in body ? parseOrganizationIds(body.organization_ids) : [],
         });
         return NextResponse.json(user, { status: 200 });
       } catch (localError) {

--- a/app/lib/localAuth.ts
+++ b/app/lib/localAuth.ts
@@ -7,6 +7,7 @@ type StoredUser = {
   password_hash: string;
   is_admin: boolean;
   is_active: boolean;
+  organization_ids: string[];
   created_at: number;
   updated_at: number;
   session_version: number;
@@ -16,6 +17,7 @@ export type LocalAuthUser = {
   username: string;
   is_admin: boolean;
   is_active: boolean;
+  organization_ids: string[];
   created_at: number;
   updated_at: number;
 };
@@ -144,6 +146,23 @@ function validateNewPassword(password: string): string {
   return text;
 }
 
+function normalizeOrganizationIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    const text = String(item ?? "").trim();
+    if (!text || seen.has(text)) {
+      continue;
+    }
+    seen.add(text);
+    result.push(text);
+  }
+  return result;
+}
+
 function b64urlEncode(raw: Buffer): string {
   return raw.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
@@ -159,6 +178,7 @@ function publicUser(user: StoredUser): LocalAuthUser {
     username: user.username,
     is_admin: Boolean(user.is_admin),
     is_active: Boolean(user.is_active),
+    organization_ids: normalizeOrganizationIds(user.organization_ids),
     created_at: Number(user.created_at || 0),
     updated_at: Number(user.updated_at || 0),
   };
@@ -298,6 +318,7 @@ function ensureDefaultAdmin(users: Record<string, StoredUser>): boolean {
       password_hash: hashPassword(DEFAULT_ADMIN_PASSWORD),
       is_admin: true,
       is_active: true,
+      organization_ids: [],
       created_at: now,
       updated_at: now,
       session_version: 0,
@@ -323,6 +344,10 @@ function ensureDefaultAdmin(users: Record<string, StoredUser>): boolean {
     existing.session_version = 0;
     changed = true;
   }
+  if (!Array.isArray(existing.organization_ids)) {
+    existing.organization_ids = [];
+    changed = true;
+  }
   if (changed) {
     existing.updated_at = now;
   }
@@ -339,6 +364,7 @@ async function saveUsersUnlocked(users: Record<string, StoredUser>): Promise<voi
         password_hash: user.password_hash,
         is_admin: Boolean(user.is_admin),
         is_active: Boolean(user.is_active),
+        organization_ids: normalizeOrganizationIds(user.organization_ids),
         created_at: user.created_at,
         updated_at: user.updated_at,
         session_version: Math.max(Number(user.session_version || 0), 0),
@@ -391,6 +417,7 @@ async function loadUsersUnlocked(): Promise<Record<string, StoredUser>> {
       password_hash: passwordHash,
       is_admin: Boolean((row as Record<string, unknown>).is_admin),
       is_active: "is_active" in (row as Record<string, unknown>) ? Boolean((row as Record<string, unknown>).is_active) : true,
+      organization_ids: normalizeOrganizationIds((row as Record<string, unknown>).organization_ids),
       created_at: Number.isFinite(createdAt) ? createdAt : now,
       updated_at: Number.isFinite(updatedAt) ? updatedAt : now,
       session_version: Number.isFinite(sessionVersion) ? sessionVersion : 0,
@@ -511,7 +538,7 @@ export async function listLocalUsers(): Promise<LocalAuthUser[]> {
   });
 }
 
-export async function createLocalUser(input: { username: string; password: string; is_admin?: boolean }): Promise<LocalAuthUser> {
+export async function createLocalUser(input: { username: string; password: string; is_admin?: boolean; organization_ids?: string[] }): Promise<LocalAuthUser> {
   return withFileLock(async () => {
     const username = validateUsername(input.username);
     const password = validateNewPassword(input.password);
@@ -526,6 +553,7 @@ export async function createLocalUser(input: { username: string; password: strin
       password_hash: hashPassword(password),
       is_admin: Boolean(input.is_admin),
       is_active: true,
+      organization_ids: normalizeOrganizationIds(input.organization_ids),
       created_at: now,
       updated_at: now,
       session_version: 0,
@@ -537,7 +565,7 @@ export async function createLocalUser(input: { username: string; password: strin
 
 export async function updateLocalUser(
   username: string,
-  updates: { is_admin?: boolean; is_active?: boolean; password?: string },
+  updates: { is_admin?: boolean; is_active?: boolean; password?: string; organization_ids?: string[] },
 ): Promise<LocalAuthUser> {
   return withFileLock(async () => {
     const canonical = normalizeUsername(validateUsername(username));
@@ -573,6 +601,15 @@ export async function updateLocalUser(
       user.password_hash = hashPassword(validateNewPassword(updates.password));
       changed = true;
       shouldRevokeSessions = true;
+    }
+
+    if (Array.isArray(updates.organization_ids)) {
+      const nextOrganizationIds = normalizeOrganizationIds(updates.organization_ids);
+      const currentOrganizationIds = normalizeOrganizationIds(user.organization_ids);
+      if (JSON.stringify(currentOrganizationIds) !== JSON.stringify(nextOrganizationIds)) {
+        user.organization_ids = nextOrganizationIds;
+        changed = true;
+      }
     }
 
     if (!changed) {

--- a/src/services/user_store.py
+++ b/src/services/user_store.py
@@ -137,9 +137,37 @@ class UserStore:
             "username": str(user.get("username") or ""),
             "is_admin": bool(user.get("is_admin")),
             "is_active": bool(user.get("is_active", True)),
+            "organization_ids": UserStore._normalize_organization_ids(
+                user.get("organization_ids")
+            ),
             "created_at": float(user.get("created_at") or 0.0),
             "updated_at": float(user.get("updated_at") or 0.0),
         }
+
+    @staticmethod
+    def _normalize_organization_ids(value: Any) -> List[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            return []
+
+        result: List[str] = []
+        seen = set()
+        for item in value:
+            text = str(item or "").strip()
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            result.append(text)
+        return result
+
+    @staticmethod
+    def _validate_organization_ids(value: Any) -> List[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("organization_ids must be a list")
+        return UserStore._normalize_organization_ids(value)
 
     @staticmethod
     def _coerce_session_version(value: Any) -> int:
@@ -156,6 +184,9 @@ class UserStore:
             "password_hash": str(user.get("password_hash") or ""),
             "is_admin": bool(user.get("is_admin")),
             "is_active": bool(user.get("is_active", True)),
+            "organization_ids": UserStore._normalize_organization_ids(
+                user.get("organization_ids")
+            ),
             "created_at": float(user.get("created_at") or 0.0),
             "updated_at": float(user.get("updated_at") or 0.0),
             "session_version": UserStore._coerce_session_version(
@@ -370,6 +401,9 @@ class UserStore:
                             "password_hash": password_hash,
                             "is_admin": bool(row.get("is_admin", False)),
                             "is_active": bool(row.get("is_active", True)),
+                            "organization_ids": self._normalize_organization_ids(
+                                row.get("organization_ids")
+                            ),
                             "created_at": created,
                             "updated_at": updated,
                             "session_version": self._coerce_session_version(
@@ -430,6 +464,7 @@ class UserStore:
                 "password_hash": self._hash_password(self._default_admin_password),
                 "is_admin": True,
                 "is_active": True,
+                "organization_ids": [],
                 "created_at": now,
                 "updated_at": now,
                 "session_version": 0,
@@ -450,6 +485,9 @@ class UserStore:
                 changed = True
             if "session_version" not in user:
                 user["session_version"] = 0
+                changed = True
+            if "organization_ids" not in user:
+                user["organization_ids"] = []
                 changed = True
             if changed:
                 user["updated_at"] = now
@@ -500,9 +538,11 @@ class UserStore:
         username: str,
         password: str,
         is_admin: bool = False,
+        organization_ids: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         clean_username = self._validate_username(username)
         clean_password = self._validate_new_password(password)
+        clean_organization_ids = self._validate_organization_ids(organization_ids)
         canonical = self._normalize_username(clean_username)
         now = time.time()
 
@@ -516,6 +556,7 @@ class UserStore:
                 "password_hash": self._hash_password(clean_password),
                 "is_admin": bool(is_admin),
                 "is_active": True,
+                "organization_ids": clean_organization_ids,
                 "created_at": now,
                 "updated_at": now,
                 "session_version": 0,
@@ -529,6 +570,7 @@ class UserStore:
         is_admin: Optional[bool] = None,
         is_active: Optional[bool] = None,
         password: Optional[str] = None,
+        organization_ids: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         canonical = self._normalize_username(self._validate_username(username))
 
@@ -573,6 +615,16 @@ class UserStore:
                 user["password_hash"] = self._hash_password(clean_password)
                 should_revoke_sessions = True
                 changed = True
+
+            if organization_ids is not None:
+                clean_organization_ids = self._validate_organization_ids(
+                    organization_ids
+                )
+                if self._normalize_organization_ids(
+                    user.get("organization_ids")
+                ) != clean_organization_ids:
+                    user["organization_ids"] = clean_organization_ids
+                    changed = True
 
             if changed:
                 if should_revoke_sessions:

--- a/tests/test_org_scope_rbac.py
+++ b/tests/test_org_scope_rbac.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("TESTING", "true")
+
+from api import runtime
+from api.main import app
+from src.services import org_matcher as org_matcher_module
+from src.services import org_storage as org_storage_module
+from src.services.user_store import reset_user_store
+
+API_KEY = os.getenv("GOVBUDGET_API_KEY", "change_me_to_a_strong_secret")
+ADMIN_PASSWORD = "AdminPass123"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    user_file = tmp_path / "users.json"
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    monkeypatch.setenv("USER_FILE", str(user_file))
+    monkeypatch.setenv("DEFAULT_ADMIN_PASSWORD", ADMIN_PASSWORD)
+    monkeypatch.setenv("JOB_QUEUE_ENABLED", "false")
+    monkeypatch.setattr(runtime, "UPLOAD_ROOT", upload_root)
+    monkeypatch.setattr(org_storage_module, "DATA_DIR", data_dir)
+    monkeypatch.setattr(org_storage_module, "ORG_FILE", data_dir / "organizations.json")
+    monkeypatch.setattr(org_storage_module, "LINKS_FILE", data_dir / "job_org_links.json")
+    monkeypatch.setattr(org_storage_module, "_storage_instance", None)
+    monkeypatch.setattr(org_matcher_module, "_matcher_instance", None)
+    reset_user_store()
+    with TestClient(app) as test_client:
+        yield test_client
+    reset_user_store()
+
+
+def _headers(session_token: str | None = None) -> dict[str, str]:
+    headers: dict[str, str] = {"X-API-Key": API_KEY}
+    if session_token:
+        headers["X-Session-Token"] = session_token
+    return headers
+
+
+def _login(client: TestClient, username: str, password: str) -> str:
+    response = client.post(
+        "/api/auth/login",
+        json={"username": username, "password": password},
+        headers=_headers(),
+    )
+    assert response.status_code == 200, response.text
+    return str(response.json()["token"])
+
+
+def _create_org(name: str, level: str, parent_id: str | None = None) -> str:
+    storage = runtime.require_org_storage()
+    org = runtime.Organization(
+        id=runtime.Organization.generate_id(name, level, parent_id),
+        name=name,
+        level=level,
+        parent_id=parent_id,
+        keywords=[name],
+    )
+    return str(storage.add(org).id)
+
+
+def _create_job(job_id: str, *, owner: str, org_id: str) -> None:
+    job_dir = runtime.UPLOAD_ROOT / job_id
+    job_dir.mkdir(parents=True, exist_ok=True)
+    (job_dir / "source.pdf").write_bytes(b"%PDF-1.4\n%%EOF\n")
+    runtime.write_json_file(
+        job_dir / "status.json",
+        {
+            "job_id": job_id,
+            "status": "done",
+            "filename": "source.pdf",
+            "organization_id": org_id,
+            "created_by": owner,
+            "result": {
+                "issues": {
+                    "all": [{"id": f"{job_id}-issue", "title": "issue"}],
+                    "error": [],
+                    "warn": [],
+                    "info": [],
+                }
+            },
+        },
+    )
+    runtime.require_org_storage().link_job(job_id, org_id, match_type="manual")
+
+
+def _setup_org_tree() -> dict[str, str]:
+    dept_a = _create_org("部门A", "department")
+    unit_a1 = _create_org("单位A1", "unit", dept_a)
+    unit_a2 = _create_org("单位A2", "unit", dept_a)
+    dept_b = _create_org("部门B", "department")
+    unit_b1 = _create_org("单位B1", "unit", dept_b)
+    return {
+        "dept_a": dept_a,
+        "unit_a1": unit_a1,
+        "unit_a2": unit_a2,
+        "dept_b": dept_b,
+        "unit_b1": unit_b1,
+    }
+
+
+def test_admin_can_assign_user_organization_scope(client: TestClient):
+    orgs = _setup_org_tree()
+    admin_token = _login(client, "admin", ADMIN_PASSWORD)
+
+    created = client.post(
+        "/api/users",
+        headers=_headers(admin_token),
+        json={
+            "username": "dept_viewer",
+            "password": "DeptPass123",
+            "organization_ids": [orgs["dept_a"]],
+        },
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["organization_ids"] == [orgs["dept_a"]]
+
+    updated = client.patch(
+        "/api/users/dept_viewer",
+        headers=_headers(admin_token),
+        json={"organization_ids": [orgs["unit_b1"]]},
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["organization_ids"] == [orgs["unit_b1"]]
+
+
+def test_unknown_organization_scope_is_rejected(client: TestClient):
+    admin_token = _login(client, "admin", ADMIN_PASSWORD)
+
+    response = client.post(
+        "/api/users",
+        headers=_headers(admin_token),
+        json={
+            "username": "bad_scope",
+            "password": "BadScope123",
+            "organization_ids": ["missing-org"],
+        },
+    )
+
+    assert response.status_code == 400
+    assert "unknown organization_ids" in response.json()["detail"]
+
+
+def test_department_scope_can_access_child_unit_jobs(client: TestClient):
+    orgs = _setup_org_tree()
+    _create_job("a1-job", owner="uploader", org_id=orgs["unit_a1"])
+    _create_job("b1-job", owner="uploader", org_id=orgs["unit_b1"])
+
+    admin_token = _login(client, "admin", ADMIN_PASSWORD)
+    client.post(
+        "/api/users",
+        headers=_headers(admin_token),
+        json={
+            "username": "dept_a_reader",
+            "password": "DeptAReader1",
+            "organization_ids": [orgs["dept_a"]],
+        },
+    )
+    token = _login(client, "dept_a_reader", "DeptAReader1")
+
+    allowed = client.get("/api/jobs/a1-job", headers=_headers(token))
+    denied = client.get("/api/jobs/b1-job", headers=_headers(token))
+    jobs = client.get(
+        f"/api/organizations/{orgs['dept_a']}/jobs?include_children=true",
+        headers=_headers(token),
+    )
+
+    assert allowed.status_code == 200
+    assert denied.status_code == 403
+    assert jobs.status_code == 200
+    assert {item["job_id"] for item in jobs.json()["jobs"]} == {"a1-job"}
+
+
+def test_unit_scope_does_not_leak_sibling_unit_jobs_or_stats(client: TestClient):
+    orgs = _setup_org_tree()
+    _create_job("a1-job", owner="uploader", org_id=orgs["unit_a1"])
+    _create_job("a2-job", owner="uploader", org_id=orgs["unit_a2"])
+
+    admin_token = _login(client, "admin", ADMIN_PASSWORD)
+    client.post(
+        "/api/users",
+        headers=_headers(admin_token),
+        json={
+            "username": "unit_reader",
+            "password": "UnitReader1",
+            "organization_ids": [orgs["unit_a1"]],
+        },
+    )
+    token = _login(client, "unit_reader", "UnitReader1")
+
+    org_tree = client.get("/api/organizations", headers=_headers(token))
+    sibling_jobs = client.get(
+        f"/api/organizations/{orgs['unit_a2']}/jobs",
+        headers=_headers(token),
+    )
+
+    assert org_tree.status_code == 200
+    assert sibling_jobs.status_code == 403
+    root = org_tree.json()["tree"][0]
+    assert root["id"] == orgs["dept_a"]
+    assert root["job_count"] == 1
+    assert [child["id"] for child in root["children"]] == [orgs["unit_a1"]]
+    assert root["children"][0]["job_count"] == 1


### PR DESCRIPTION
## Summary
- Add `organization_ids` to backend and local fallback user records so admins can assign organization scopes.
- Extend job access checks from owner-only to owner or authorized organization subtree.
- Filter organization trees, organization lists, department endpoints, department stats, and organization job lists by the logged-in user's organization scope.
- Prevent Next.js organization/department proxy routes from falling back to local data when the backend returns explicit 401/403.
- Add regression coverage for organization scope assignment, invalid scopes, department subtree access, sibling isolation, and scoped stats.

## Validation
- `ruff check api src tests`
- `mypy api src tests`
- `pytest` -> 352 passed, 1 Starlette TestClient deprecation warning
- `npm --prefix app run lint`
- `npm --prefix app run build`
- `npm --prefix app run test:ui-adapters`
- `git diff --check`

## Notes
- This is organization-scope RBAC on top of the existing job-owner isolation.
- Admins still see all organizations and jobs.
- Regular users can access jobs they created, plus jobs under their assigned organization subtree.
- Users with no organization scope still retain access to their own jobs and legacy unowned jobs per the previous compatibility rule.
- This PR adds API support for scope assignment; a richer visual picker in the user management UI can be added separately.