### PR TITLE
Remove hardcoded Postgres compose credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,10 @@
 # ----------------------------------------
 # PostgreSQL Database Configuration
 # ----------------------------------------
-DATABASE_URL=postgres://postgres:your_password@localhost:5432/fiscal_db
+POSTGRES_USER=govbudget_local
+POSTGRES_PASSWORD=change_me_local_postgres_password
+POSTGRES_DB=fiscal_db
+DATABASE_URL=postgres://govbudget_local:change_me_local_postgres_password@localhost:5432/fiscal_db
 PG_SCHEMA=public
 
 # ----------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
-# PostgreSQL for GovBudgetChecker
-# 启动: docker compose up -d
-# 停止: docker compose down
+# PostgreSQL for GovBudgetChecker.
+# Copy .env.example to .env and set POSTGRES_USER / POSTGRES_PASSWORD first.
+# Start: docker compose up -d
+# Stop: docker compose down
 
 services:
   postgres:
@@ -9,14 +10,14 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_USER: fiscal_user
-      POSTGRES_PASSWORD: fiscal_pass
-      POSTGRES_DB: fiscal_db
+      POSTGRES_USER: ${POSTGRES_USER:?Set POSTGRES_USER in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-fiscal_db}
     volumes:
       - fiscal_pgdata:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U fiscal_user -d fiscal_db" ]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -15,12 +15,12 @@ SELECT 'CREATE DATABASE fiscal_db'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'fiscal_db')\gexec
 
 -- 可选：创建专用用户（如果不想用 postgres 用户）
--- CREATE USER fiscal_user WITH PASSWORD 'fiscal_pass';
--- GRANT ALL PRIVILEGES ON DATABASE fiscal_db TO fiscal_user;
+-- CREATE USER govbudget_local WITH PASSWORD 'change_me_local_postgres_password';
+-- GRANT ALL PRIVILEGES ON DATABASE fiscal_db TO govbudget_local;
 
 -- 连接到 fiscal_db 后执行以下命令授权（可选）
 -- \c fiscal_db
--- GRANT ALL ON SCHEMA public TO fiscal_user;
+-- GRANT ALL ON SCHEMA public TO govbudget_local;
 
 \echo '=========================================='
 \echo 'fiscal_db 数据库创建完成！'


### PR DESCRIPTION
## Summary
- replace hardcoded docker-compose PostgreSQL credentials with required environment variables
- add matching Postgres variables to .env.example
- update init_db.sql example comments to avoid the old fiscal_user/fiscal_pass sample credential pair

## Validation
- docker compose --env-file .env.example config
- rg "fiscal_pass|POSTGRES_PASSWORD: fiscal_pass|POSTGRES_USER: fiscal_user|pg_isready -U fiscal_user" -n .
- git diff --check
- git diff --cached --check
